### PR TITLE
Improved MUI Layout

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -22,6 +22,7 @@ body, html {
   margin: 0;
   height: 100%;
   width: 100%;
+  overflow: hidden;
 
   color: rgb(30, 30, 30);
 }
@@ -30,10 +31,13 @@ body, html {
   width: 100vw;
   height: 100vh;
   display: flex;
+  overflow: auto;
 }
 
 #sidebar {
   width: 250px;
+  position: sticky;
+  top: 0;
 }
 
 #sidebar-header {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -18,7 +18,7 @@
   box-sizing: border-box;
 }
 
-body, html, #vendor-page, #stakeholder-page {
+body, html {
   margin: 0;
   height: 100%;
   width: 100%;
@@ -27,8 +27,8 @@ body, html, #vendor-page, #stakeholder-page {
 }
 
 #dashboard {
-  width: 100%;
-  height: 100%;
+  width: 100vw;
+  height: 100vh;
   display: flex;
 }
 

--- a/app/javascript/components/StakeholderPage.jsx
+++ b/app/javascript/components/StakeholderPage.jsx
@@ -18,7 +18,7 @@ const StakeholderPage = (props) => {
       ]}>
       <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
         <Grid container spacing={3}>
-          <Grid item xs={12} md={8} lg={9}>
+          <Grid item xs={12} md={12} lg={12}>
             <Panel title="Example Panel">
 
             </Panel>

--- a/app/javascript/components/StakeholderPage.jsx
+++ b/app/javascript/components/StakeholderPage.jsx
@@ -4,28 +4,34 @@ import CreateOutlinedIcon from '@mui/icons-material/CreateOutlined';
 import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined';
 import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
+import { ThemeProvider, createTheme, responsiveFontSizes } from '@mui/material/styles';
 
 import Dashboard from './Dashboard';
 import Panel from './Panel';
 
+let theme = createTheme();
+theme = responsiveFontSizes(theme);
+
 const StakeholderPage = (props) => {
   return (
-    <Dashboard
-      signOutPath={props.signOutPath}
-      sidebar={[
-        ['Dashboard', <HomeOutlinedIcon />],
-        ['Products', <CreateOutlinedIcon />]
-      ]}>
-      <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
-        <Grid container spacing={3}>
-          <Grid item xs={12} md={12} lg={12}>
-            <Panel title="Example Panel">
+    <ThemeProvider theme={theme}>
+      <Dashboard
+        signOutPath={props.signOutPath}
+        sidebar={[
+          ['Dashboard', <HomeOutlinedIcon />],
+          ['Products', <CreateOutlinedIcon />]
+        ]}>
+        <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
+          <Grid container spacing={3}>
+            <Grid item xs={12} md={12} lg={12}>
+              <Panel title="Example Panel">
 
-            </Panel>
+              </Panel>
+            </Grid>
           </Grid>
-        </Grid>
-      </Container>
-    </Dashboard>
+        </Container>
+      </Dashboard>
+    </ThemeProvider>
   );
 }
 

--- a/app/javascript/components/VendorPage.jsx
+++ b/app/javascript/components/VendorPage.jsx
@@ -5,29 +5,35 @@ import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined';
 import StorefrontOutlinedIcon from '@mui/icons-material/StorefrontOutlined';
 import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
+import { ThemeProvider, createTheme, responsiveFontSizes } from '@mui/material/styles';
 
 import Dashboard from './Dashboard';
 import Panel from './Panel';
 
+let theme = createTheme();
+theme = responsiveFontSizes(theme);
+
 const VendorPage = (props) => {
   return (
-    <Dashboard
-      signOutPath={props.signOutPath}
-      sidebar={[
-        ['Dashboard', <HomeOutlinedIcon />],
-        ['Clients', <BusinessOutlinedIcon />],
-        ['Vendors', <StorefrontOutlinedIcon />]
-      ]}>
-      <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
-        <Grid container spacing={3}>
-          <Grid item xs={12} md={12} lg={12}>
-            <Panel title="Example Panel">
+    <ThemeProvider theme={theme}>
+      <Dashboard
+        signOutPath={props.signOutPath}
+        sidebar={[
+          ['Dashboard', <HomeOutlinedIcon />],
+          ['Clients', <BusinessOutlinedIcon />],
+          ['Vendors', <StorefrontOutlinedIcon />]
+        ]}>
+        <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
+          <Grid container spacing={3}>
+            <Grid item xs={12} md={12} lg={12}>
+              <Panel title="Example Panel">
 
-            </Panel>
+              </Panel>
+            </Grid>
           </Grid>
-        </Grid>
-      </Container>
-    </Dashboard>
+        </Container>
+      </Dashboard>
+    </ThemeProvider>
   );
 }
 

--- a/app/javascript/components/VendorPage.jsx
+++ b/app/javascript/components/VendorPage.jsx
@@ -20,7 +20,7 @@ const VendorPage = (props) => {
       ]}>
       <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
         <Grid container spacing={3}>
-          <Grid item xs={12} md={8} lg={9}>
+          <Grid item xs={12} md={12} lg={12}>
             <Panel title="Example Panel">
 
             </Panel>

--- a/app/views/vendor/dashboard/index.html.erb
+++ b/app/views/vendor/dashboard/index.html.erb
@@ -1,1 +1,1 @@
-<%= react_component("VendorPage", props: @vendor_props, prerender: false, id: 'vendor-page') %>
+<%= react_component("VendorPage", props: @vendor_props, prerender: false) %>


### PR DESCRIPTION
A few commits for regularizing the MUI based layout:

- Dashboard now always sets itself to the viewport width/height. (As a side effect it's no longer necessary to target the react_on_rails generated container to set its width/height in CSS so I removed setting the id manually.)
- The example panel was incorrectly not filling its 12 "columns" on larger screen sizes.
- The sidebar is now sticky and holds its position on scroll, staying on screen at all times.
- Added ThemeProvider to the dashboards. This will make some styling changes easier but it does alter the dashboard structure a bit. (This might/will cause conflicts, sorry! Should be easy enough to cut and repaste though.)