### PR TITLE
Add ActionCenter Component

### DIFF
--- a/app/javascript/components/ActionCenter.jsx
+++ b/app/javascript/components/ActionCenter.jsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Typography from '@mui/material/Typography';
+
+const ActionCenter = (props) => {
+  const items = props.items.map(([mainText, amount, category, path, Icon]) =>
+    <ListItem key={mainText} disablePadding>
+      <ListItemButton component={Link} to={path}>
+        <ListItemIcon>
+          <Icon color={category} />
+        </ListItemIcon>
+        <ListItemText
+          primary={
+            <React.Fragment>
+              <Typography sx={{ mr: '10px' }} component="span" color={category}>
+                {amount}
+              </Typography>
+              <Typography component="span" color={category}>
+                {mainText}
+              </Typography>
+            </React.Fragment>
+          } />
+      </ListItemButton>
+    </ListItem>
+  );
+
+  return (
+    <List>
+      {items}
+    </List>
+  );
+}
+
+export default ActionCenter;


### PR DESCRIPTION
Added a simple component for displaying a list of actionable items.

Example Usage:
```jsx
<Panel title="Action Center">
  <ActionCenter items={[
    ['Order(s) Failed On Payment', 5, 'error', '/', ProductionQuantityLimitsOutlinedIcon],
    ['Client(s) Have Unspent Funds', 3, 'warning', '/', PeopleAltOutlinedIcon]
  ]} />
</Panel>
```

https://user-images.githubusercontent.com/9350755/148434269-ba883aa8-f7b8-41bc-bfa4-8a3ba41b7fd5.mp4