### PR TITLE
Persistent Data Table Filters

### DIFF
--- a/app/javascript/DataTables/OrdersDataTable.jsx
+++ b/app/javascript/DataTables/OrdersDataTable.jsx
@@ -1,24 +1,25 @@
-import * as React from 'react';
+import React, { useState } from 'react';
 import { DataGrid } from '@mui/x-data-grid';
-
-const columns = [
-  { field: 'id', headerName: 'Order ID', width: 100 },
-  { field: 'vendor_name', headerName: 'Vendor', width: 130 },
-  { field: 'product_name', headerName: 'Product', width: 200 },
-  { field: 'product_price', headerName: 'Product Price', width: 130 },
-  { field: 'status', headerName: 'Order Status', width: 130 },
-  { field: 'sender_name', headerName: 'Sender Name', width: 130 },
-  { field: 'recipient_name', headerName: 'Recipient Name', width: 130 },
-  { field: 'created_at', headerName: 'Created At', width: 130 },
-  { field: 'total_amount', headerName: 'Amount', type: 'number', width: 120 },
-];
 
 const OrdersDataTable = (props) => {
   const rows = props.data;
 
+  const columns = props.persistence.hideifyColumns([
+    { field: 'id', headerName: 'Order ID', width: 100 },
+    { field: 'vendor_name', headerName: 'Vendor', width: 130 },
+    { field: 'product_name', headerName: 'Product', width: 200 },
+    { field: 'product_price', headerName: 'Product Price', width: 130 },
+    { field: 'status', headerName: 'Order Status', width: 130 },
+    { field: 'sender_name', headerName: 'Sender Name', width: 130 },
+    { field: 'recipient_name', headerName: 'Recipient Name', width: 130 },
+    { field: 'created_at', headerName: 'Created At', width: 130 },
+    { field: 'total_amount', headerName: 'Amount', type: 'number', width: 120 },
+  ]);
+
   return (
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
+        {...props.persistence.attributes}
         rows={rows}
         columns={columns}
         pageSize={5}

--- a/app/javascript/components/DataGridPersistence.jsx
+++ b/app/javascript/components/DataGridPersistence.jsx
@@ -6,16 +6,18 @@ const DataGridPersistence = (storageKey) => {
     hideifyColumns: (columns) => columns
   };
 
+  const [dirty, setDirty] = useState(false);
+
   const [sort, setSort] = useState(JSON.parse(localStorage.getItem(`${storageKey}-sort`)));
   const changeSort = (sort) => {
     setSort(sort);
-    localStorage.setItem(`${storageKey}-sort`, JSON.stringify(sort));
+    setDirty(true);
   }
 
   const [filter, setFilter] = useState(JSON.parse(localStorage.getItem(`${storageKey}-filter`)));
   const changeFilter = (filter) => {
     setFilter(filter);
-    localStorage.setItem(`${storageKey}-filter`, JSON.stringify(filter));
+    setDirty(true);
   }
 
   const [hidden, setHidden] = useState(JSON.parse(localStorage.getItem(`${storageKey}-hidden`)) || {});
@@ -27,12 +29,19 @@ const DataGridPersistence = (storageKey) => {
       updated[column.field] = true;
     }
     setHidden(updated);
-    localStorage.setItem(`${storageKey}-hidden`, JSON.stringify(updated));
+    setDirty(true);
   }
   const hideifyColumns = (columns) => columns.map((column) => {
     column.hide = hidden[column.field];
     return column;
   });
+
+  const save = () => {
+    localStorage.setItem(`${storageKey}-sort`, JSON.stringify(sort));
+    localStorage.setItem(`${storageKey}-filter`, JSON.stringify(filter));
+    localStorage.setItem(`${storageKey}-hidden`, JSON.stringify(hidden));
+    setDirty(false);
+  }
 
   const attributes = {
     ...(sort && {
@@ -48,7 +57,9 @@ const DataGridPersistence = (storageKey) => {
 
   return {
     attributes,
-    hideifyColumns
+    hideifyColumns,
+    dirty,
+    save
   };
 }
 

--- a/app/javascript/components/DataGridPersistence.jsx
+++ b/app/javascript/components/DataGridPersistence.jsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+
+const DataGridPersistence = (storageKey) => {
+  if (!storageKey) return {
+    attributes: {},
+    hideifyColumns: (columns) => columns
+  };
+
+  const [sort, setSort] = useState(JSON.parse(localStorage.getItem(`${storageKey}-sort`)));
+  const changeSort = (sort) => {
+    setSort(sort);
+    localStorage.setItem(`${storageKey}-sort`, JSON.stringify(sort));
+  }
+
+  const [filter, setFilter] = useState(JSON.parse(localStorage.getItem(`${storageKey}-filter`)));
+  const changeFilter = (filter) => {
+    setFilter(filter);
+    localStorage.setItem(`${storageKey}-filter`, JSON.stringify(filter));
+  }
+
+  const [hidden, setHidden] = useState(JSON.parse(localStorage.getItem(`${storageKey}-hidden`)) || {});
+  const changeHidden = (column) => {
+    const updated = { ...hidden };
+    if (column.isVisible) {
+      delete updated[column.field];
+    } else {
+      updated[column.field] = true;
+    }
+    setHidden(updated);
+    localStorage.setItem(`${storageKey}-hidden`, JSON.stringify(updated));
+  }
+  const hideifyColumns = (columns) => columns.map((column) => {
+    column.hide = hidden[column.field];
+    return column;
+  });
+
+  const attributes = {
+    ...(sort && {
+      sortModel: sort
+    }),
+    ...(filter && {
+      filterModel: filter
+    }),
+    onSortModelChange: changeSort,
+    onFilterModelChange: changeFilter,
+    onColumnVisibilityChange: changeHidden
+  };
+
+  return {
+    attributes,
+    hideifyColumns
+  };
+}
+
+export default DataGridPersistence;

--- a/app/javascript/components/SwitchablePanel.jsx
+++ b/app/javascript/components/SwitchablePanel.jsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import ListSubheader from '@mui/material/ListSubheader';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
+import DataGridPersistence from './DataGridPersistence';
 import Panel from './Panel';
 
 const SwitchablePanel = (props) => {
@@ -17,6 +19,14 @@ const SwitchablePanel = (props) => {
     setPanel(panel);
     localStorage.setItem(storageKey, panel);
     close();
+  }
+
+  const persistence = {};
+  for (var panelKey in props.panels) {
+    const panel = props.panels[panelKey];
+    if (panel.persistence) {
+      persistence[panelKey] = DataGridPersistence(`table-${props.id}-${panelKey}`);
+    }
   }
 
   const title = (
@@ -36,12 +46,27 @@ const SwitchablePanel = (props) => {
           }
         })}
       </Menu>
+      {
+        (persistence[panel] && persistence[panel].dirty) ?
+          <Button
+            variant="contained"
+            onClick={persistence[panel].save}
+            sx={{ 'float': 'right' }}
+          >
+            Make Default View
+          </Button> :
+          <React.Fragment />
+      }
     </React.Fragment>
   );
 
   return (
     <Panel title={title} sx={props.sx}>
-      {props.panels[panel].content}
+      {
+        persistence[panel] ?
+          props.panels[panel].content(persistence[panel]) :
+          props.panels[panel].content
+      }
     </Panel>
   );
 }

--- a/app/javascript/components/stakeholder/Index.jsx
+++ b/app/javascript/components/stakeholder/Index.jsx
@@ -21,7 +21,8 @@ const Index = (props) => {
     },
     'orders-table': {
       title: 'Orders',
-      content: <OrdersDataTable data={props.data} />
+      persistence: true,
+      content: (persistence) => <OrdersDataTable data={props.data} persistence={persistence} />
     },
     'graphs': {
       header: true,


### PR DESCRIPTION
This change adds persistence to data tables in regards to sorting, filter and hiding columns. This allows for custom data views on the dashboards according to a user's needs.

![Screenshot 2022-01-10 at 10 28 11](https://user-images.githubusercontent.com/9350755/148751168-06935be9-6284-4c7c-8677-9474a6bb4eae.png)